### PR TITLE
Add environment template and fix .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+
+# CRITICAL: Service Role Key for Admin Operations
+# This key bypasses RLS and allows access to auth.users
+# Get this from Supabase Dashboard > Settings > API > service_role key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
+# Development
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files
-.env*
+# env files (allow .env.example but ignore actual .env files)
+.env
+.env.local
+.env.*.local
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
- Add .env.example template for easy setup
- Fix .gitignore to allow .env.example but keep .env.local private
- Provides clear template for service role key configuration