### PR TITLE
Debug player performance tab crash

### DIFF
--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -63,8 +63,8 @@ export default function PerformancePage() {
   const canEdit = profile?.role && ["admin", "manager", "coach"].includes(profile.role.toLowerCase())
   const canViewDashboard = profile?.role && ["admin", "manager"].includes(profile.role.toLowerCase())
 
-  if (!profile || !users) {
-    return <div className="text-center py-8 text-muted-foreground">Loading...</div>;
+  if (!profile || !users || users.length === 0) {
+    return <div className="text-center py-8 text-muted-foreground">Loading user data...</div>;
   }
 
   return (

--- a/components/performance/player-performance-submit.tsx
+++ b/components/performance/player-performance-submit.tsx
@@ -46,6 +46,10 @@ export function PlayerPerformanceSubmit({ onPerformanceAdded, users }: { onPerfo
     ? users.filter(u => u.role === "player" && (profile?.role === "admin" || profile?.role === "manager" || u.team_id === profile?.team_id))
     : users.filter(u => u.id === profile?.id)
 
+  if (!eligiblePlayers.length) {
+    return <div className="text-center py-8 text-red-500">No eligible player profile found. Please contact support.</div>;
+  }
+
   useEffect(() => {
     // For staff, update teamId and slots when player changes
     if (isStaff && formData.player_id) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react": "^18",
         "react-day-picker": "8.10.1",
         "react-dom": "^18",
+        "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.54.1",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
@@ -3342,6 +3343,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-hook-form": {


### PR DESCRIPTION
Add defensive checks to Performance page components to prevent crashes for players when user data is missing.

The application crashed for players navigating to the Performance tab because the `users` data might be empty or the `profile` incomplete, leading to components attempting to render with undefined values. This PR introduces guards to ensure components only render when necessary data is available, providing a graceful fallback message instead of a crash.