### PR TITLE
Update project to auth v3

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -302,7 +302,7 @@ export default function AnalyticsPage() {
       const options: DashboardDataOptions = {
         role: userRole,
         userId: profile.id,
-        teamId: profile.team_id,
+        teamId: profile.team_id || undefined,
         timeframe: selectedTimeframe
       }
 

--- a/app/dashboard/attendance/page.tsx
+++ b/app/dashboard/attendance/page.tsx
@@ -424,7 +424,7 @@ export default function AttendancePage() {
                             .sort((a, b) => b.percentage - a.percentage)
                             .slice(0, 5)
                         }}
-                        teamId={selectedTeam !== 'all' ? selectedTeam : profile?.team_id}
+                        teamId={selectedTeam !== 'all' ? selectedTeam : profile?.team_id || undefined}
                         variant="outline"
                       />
                     </CardTitle>

--- a/app/dashboard/discord-portal/page.tsx
+++ b/app/dashboard/discord-portal/page.tsx
@@ -18,7 +18,7 @@ import {
   Plus,
   AlertTriangle
 } from "lucide-react"
-import { DashboardPermissions } from "@/lib/dashboard-permissions"
+import { DashboardPermissions, type UserRole } from "@/lib/dashboard-permissions"
 
 interface CommunicationStats {
   totalMessages: number
@@ -39,7 +39,7 @@ export default function CommunicationPage() {
   const [customStartDate, setCustomStartDate] = useState<string>("")
   const [customEndDate, setCustomEndDate] = useState<string>("")
 
-  const permissions = DashboardPermissions.getPermissions(profile?.role || 'player')
+  const permissions = DashboardPermissions.getPermissions((profile?.role as UserRole) || 'player')
 
   useEffect(() => {
     if (profile?.id) {

--- a/app/dashboard/discord-portal/webhooks/page.tsx
+++ b/app/dashboard/discord-portal/webhooks/page.tsx
@@ -23,7 +23,7 @@ import {
   ExternalLink,
   Loader2
 } from "lucide-react"
-import { DashboardPermissions } from "@/lib/dashboard-permissions"
+import { DashboardPermissions, type UserRole } from "@/lib/dashboard-permissions"
 
 interface DiscordWebhook {
   id: string
@@ -60,7 +60,7 @@ export default function WebhooksPage() {
   const [validating, setValidating] = useState(false)
   const [submitting, setSubmitting] = useState(false)
 
-  const permissions = DashboardPermissions.getPermissions(profile?.role)
+  const permissions = DashboardPermissions.getPermissions(profile?.role as UserRole)
 
   useEffect(() => {
     if (profile?.id) {

--- a/app/dashboard/finance/page.tsx
+++ b/app/dashboard/finance/page.tsx
@@ -850,7 +850,7 @@ export default function FinancePage() {
                         amount: Math.max(...filteredExpenses.map(e => e.total), 0)
                       }
                     }}
-                    teamId={selectedTeam !== 'all' ? selectedTeam : profile?.team_id}
+                    teamId={selectedTeam !== 'all' ? selectedTeam : profile?.team_id || undefined}
                     variant="outline"
                     webhookTypes={['admin']} // Finance data only to admin channels
                   />

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -798,7 +798,7 @@ export default function PerformancePage() {
                         time_period: selectedTimePeriod !== 'all'
                       }
                     }}
-                    teamId={selectedTeam !== 'all' ? selectedTeam : profile?.team_id}
+                    teamId={selectedTeam !== 'all' ? selectedTeam : profile?.team_id || undefined}
                     variant="outline"
                   />
                 </CardTitle>
@@ -818,7 +818,50 @@ export default function PerformancePage() {
             <PerformanceDashboard 
               performances={filteredPerformances} 
               users={users} 
-              currentUser={profile}
+              currentUser={profile ? {
+                ...profile,
+                role_level: null,
+                avatar_url: null,
+                created_at: '',
+                provider: '',
+                phone: null,
+                gaming_stats: null,
+                achievements: null,
+                last_seen: null,
+                agreement_status: '',
+                agreement_version: null,
+                agreement_signed_at: null,
+                preferred_slot_times: null,
+                preferred_game_modes: null,
+                performance_goals: null,
+                performance_notes: null,
+                coach_notes: null,
+                team_role: null,
+                onboarding_completed: false,
+                updated_at: null,
+                last_profile_update: null,
+                discord_id: null,
+                timezone: null,
+                practice_schedule: null,
+                availability: null,
+                emergency_contact: null,
+                date_of_birth: null,
+                guardian_contact: null,
+                medical_info: null,
+                dietary_restrictions: null,
+                experience_level: null,
+                previous_teams: null,
+                goals: null,
+                referral_source: null,
+                social_media: null,
+                streaming_info: null,
+                hardware_info: null,
+                internet_speed: null,
+                language_preferences: null,
+                communication_preferences: null,
+                training_focus: null,
+                improvement_areas: null
+              } as UserProfile : null}
               showFilters={false}
               compact={false}
             />

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -818,50 +818,6 @@ export default function PerformancePage() {
             <PerformanceDashboard 
               performances={filteredPerformances} 
               users={users} 
-              currentUser={profile ? {
-                ...profile,
-                role_level: null,
-                avatar_url: null,
-                created_at: '',
-                provider: '',
-                phone: null,
-                gaming_stats: null,
-                achievements: null,
-                last_seen: null,
-                agreement_status: '',
-                agreement_version: null,
-                agreement_signed_at: null,
-                preferred_slot_times: null,
-                preferred_game_modes: null,
-                performance_goals: null,
-                performance_notes: null,
-                coach_notes: null,
-                team_role: null,
-                onboarding_completed: false,
-                updated_at: null,
-                last_profile_update: null,
-                discord_id: null,
-                timezone: null,
-                practice_schedule: null,
-                availability: null,
-                emergency_contact: null,
-                date_of_birth: null,
-                guardian_contact: null,
-                medical_info: null,
-                dietary_restrictions: null,
-                experience_level: null,
-                previous_teams: null,
-                goals: null,
-                referral_source: null,
-                social_media: null,
-                streaming_info: null,
-                hardware_info: null,
-                internet_speed: null,
-                language_preferences: null,
-                communication_preferences: null,
-                training_focus: null,
-                improvement_areas: null
-              } as UserProfile : null}
               showFilters={false}
               compact={false}
             />

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -40,17 +40,17 @@ export default function ProfilePage() {
   // Permissions
   const canView = displayProfile && currentProfile ? canViewProfile(
     currentProfile.role as any,
-    currentProfile.team_id,
+    currentProfile.team_id || null,
     displayProfile.id,
-    displayProfile.team_id,
+    displayProfile.team_id || null,
     displayProfile.profile_visibility as any,
     currentProfile.id
   ) : false
   const canEdit = displayProfile && currentProfile ? canEditProfile(
     currentProfile.role as any,
-    currentProfile.team_id,
+    currentProfile.team_id || null,
     displayProfile.id,
-    displayProfile.team_id,
+    displayProfile.team_id || null,
     currentProfile.id
   ) : false
   const canSearchAll = ['admin', 'manager'].includes(currentProfile?.role || '')
@@ -210,8 +210,114 @@ export default function ProfilePage() {
     <div className="container mx-auto px-4 py-8 space-y-8">
       {/* Profile Header */}
       <ProfileHeader 
-        profile={displayProfile} 
-        viewerProfile={currentProfile}
+        profile={displayProfile ? {
+          ...displayProfile,
+          // Add missing properties that ProfileHeader might need with default values
+          role_level: (displayProfile as any).role_level || null,
+          avatar_url: (displayProfile as any).avatar_url || null,
+          created_at: (displayProfile as any).created_at || '',
+          provider: (displayProfile as any).provider || '',
+          phone: (displayProfile as any).phone || null,
+          gaming_stats: (displayProfile as any).gaming_stats || null,
+          achievements: (displayProfile as any).achievements || null,
+          last_seen: (displayProfile as any).last_seen || null,
+          agreement_status: (displayProfile as any).agreement_status || '',
+          agreement_version: (displayProfile as any).agreement_version || null,
+          agreement_signed_at: (displayProfile as any).agreement_signed_at || null,
+          preferred_slot_times: (displayProfile as any).preferred_slot_times || null,
+          preferred_game_modes: (displayProfile as any).preferred_game_modes || null,
+          performance_goals: (displayProfile as any).performance_goals || null,
+          performance_notes: (displayProfile as any).performance_notes || null,
+          coach_notes: (displayProfile as any).coach_notes || null,
+          team_role: (displayProfile as any).team_role || null,
+          onboarding_completed: (displayProfile as any).onboarding_completed || false,
+          updated_at: (displayProfile as any).updated_at || null,
+          last_profile_update: (displayProfile as any).last_profile_update || null,
+          discord_id: (displayProfile as any).discord_id || null,
+          timezone: (displayProfile as any).timezone || null,
+          practice_schedule: (displayProfile as any).practice_schedule || null,
+          availability: (displayProfile as any).availability || null,
+          emergency_contact: (displayProfile as any).emergency_contact || null,
+          date_of_birth: (displayProfile as any).date_of_birth || null,
+          guardian_contact: (displayProfile as any).guardian_contact || null,
+          medical_info: (displayProfile as any).medical_info || null,
+          dietary_restrictions: (displayProfile as any).dietary_restrictions || null,
+          experience_level: (displayProfile as any).experience_level || null,
+          previous_teams: (displayProfile as any).previous_teams || null,
+          goals: (displayProfile as any).goals || null,
+          referral_source: (displayProfile as any).referral_source || null,
+          social_media: (displayProfile as any).social_media || null,
+          streaming_info: (displayProfile as any).streaming_info || null,
+          hardware_info: (displayProfile as any).hardware_info || null,
+          internet_speed: (displayProfile as any).internet_speed || null,
+          language_preferences: (displayProfile as any).language_preferences || null,
+          communication_preferences: (displayProfile as any).communication_preferences || null,
+          training_focus: (displayProfile as any).training_focus || null,
+          improvement_areas: (displayProfile as any).improvement_areas || null,
+          // Additional properties that might be used by ProfileHeader
+          full_name: (displayProfile as any).full_name || null,
+          display_name: (displayProfile as any).display_name || null,
+          bio: (displayProfile as any).bio || null,
+          bgmi_id: (displayProfile as any).bgmi_id || null,
+          bgmi_tier: (displayProfile as any).bgmi_tier || null,
+          profile_visibility: (displayProfile as any).profile_visibility || 'team',
+          contact_number: (displayProfile as any).contact_number || null,
+          address: (displayProfile as any).address || null
+        } : null} 
+        viewerProfile={currentProfile ? {
+          ...currentProfile,
+          // Add missing properties for currentProfile too
+          role_level: (currentProfile as any).role_level || null,
+          avatar_url: (currentProfile as any).avatar_url || null,
+          created_at: (currentProfile as any).created_at || '',
+          provider: (currentProfile as any).provider || '',
+          phone: (currentProfile as any).phone || null,
+          gaming_stats: (currentProfile as any).gaming_stats || null,
+          achievements: (currentProfile as any).achievements || null,
+          last_seen: (currentProfile as any).last_seen || null,
+          agreement_status: (currentProfile as any).agreement_status || '',
+          agreement_version: (currentProfile as any).agreement_version || null,
+          agreement_signed_at: (currentProfile as any).agreement_signed_at || null,
+          preferred_slot_times: (currentProfile as any).preferred_slot_times || null,
+          preferred_game_modes: (currentProfile as any).preferred_game_modes || null,
+          performance_goals: (currentProfile as any).performance_goals || null,
+          performance_notes: (currentProfile as any).performance_notes || null,
+          coach_notes: (currentProfile as any).coach_notes || null,
+          team_role: (currentProfile as any).team_role || null,
+          onboarding_completed: (currentProfile as any).onboarding_completed || false,
+          updated_at: (currentProfile as any).updated_at || null,
+          last_profile_update: (currentProfile as any).last_profile_update || null,
+          discord_id: (currentProfile as any).discord_id || null,
+          timezone: (currentProfile as any).timezone || null,
+          practice_schedule: (currentProfile as any).practice_schedule || null,
+          availability: (currentProfile as any).availability || null,
+          emergency_contact: (currentProfile as any).emergency_contact || null,
+          date_of_birth: (currentProfile as any).date_of_birth || null,
+          guardian_contact: (currentProfile as any).guardian_contact || null,
+          medical_info: (currentProfile as any).medical_info || null,
+          dietary_restrictions: (currentProfile as any).dietary_restrictions || null,
+          experience_level: (currentProfile as any).experience_level || null,
+          previous_teams: (currentProfile as any).previous_teams || null,
+          goals: (currentProfile as any).goals || null,
+          referral_source: (currentProfile as any).referral_source || null,
+          social_media: (currentProfile as any).social_media || null,
+          streaming_info: (currentProfile as any).streaming_info || null,
+          hardware_info: (currentProfile as any).hardware_info || null,
+          internet_speed: (currentProfile as any).internet_speed || null,
+          language_preferences: (currentProfile as any).language_preferences || null,
+          communication_preferences: (currentProfile as any).communication_preferences || null,
+          training_focus: (currentProfile as any).training_focus || null,
+          improvement_areas: (currentProfile as any).improvement_areas || null,
+          // Additional properties
+          full_name: (currentProfile as any).full_name || null,
+          display_name: (currentProfile as any).display_name || null,
+          bio: (currentProfile as any).bio || null,
+          bgmi_id: (currentProfile as any).bgmi_id || null,
+          bgmi_tier: (currentProfile as any).bgmi_tier || null,
+          profile_visibility: (currentProfile as any).profile_visibility || 'team',
+          contact_number: (currentProfile as any).contact_number || null,
+          address: (currentProfile as any).address || null
+        } : null}
         onEdit={() => setActiveTab('personal')}
         isEditing={false}
         showAvatarUpload={isOwnProfile && canEdit}

--- a/components/attendance/enhanced-mark-attendance.tsx
+++ b/components/attendance/enhanced-mark-attendance.tsx
@@ -27,6 +27,7 @@ import {
   Crown
 } from "lucide-react"
 import type { Database } from "@/lib/supabase"
+import type { AuthProfile } from "@/lib/auth-flow-v3"
 
 type UserProfile = Database["public"]["Tables"]["users"]["Row"]
 type Team = Database["public"]["Tables"]["teams"]["Row"]
@@ -42,7 +43,7 @@ interface PlayerAttendanceState {
 
 interface EnhancedMarkAttendanceProps {
   onAttendanceMarked: () => void
-  userProfile: UserProfile | null
+  userProfile: AuthProfile | null
   teams: Team[]
   users: UserProfile[]
 }

--- a/components/attendance/mark-attendance.tsx
+++ b/components/attendance/mark-attendance.tsx
@@ -20,13 +20,14 @@ import {
   AlertCircle
 } from "lucide-react"
 import type { Database } from "@/lib/supabase"
+import type { AuthProfile } from "@/lib/auth-flow-v3"
 
 type UserProfile = Database["public"]["Tables"]["users"]["Row"]
 type Team = Database["public"]["Tables"]["teams"]["Row"]
 
 interface MarkAttendanceProps {
   onAttendanceMarked: () => void
-  userProfile: UserProfile | null
+  userProfile: AuthProfile | null
   teams: Team[]
   users: UserProfile[]
 }

--- a/components/attendance/session-attendance.tsx
+++ b/components/attendance/session-attendance.tsx
@@ -26,6 +26,7 @@ import {
   AlertCircle
 } from "lucide-react"
 import type { Database } from "@/lib/supabase"
+import type { AuthProfile } from "@/lib/auth-flow-v3"
 
 type UserProfile = Database["public"]["Tables"]["users"]["Row"]
 type Team = Database["public"]["Tables"]["teams"]["Row"]
@@ -60,7 +61,7 @@ interface Attendance {
 }
 
 interface SessionAttendanceProps {
-  userProfile: UserProfile | null
+  userProfile: AuthProfile | null
   teams: Team[]
   users: UserProfile[]
 }

--- a/components/performance/performance-dashboard.tsx
+++ b/components/performance/performance-dashboard.tsx
@@ -28,7 +28,6 @@ type UserProfile = Database["public"]["Tables"]["users"]["Row"]
 interface PerformanceDashboardProps {
   performances: Performance[]
   users: UserProfile[]
-  currentUser: UserProfile | null
   showFilters?: boolean
   compact?: boolean
 }
@@ -36,7 +35,6 @@ interface PerformanceDashboardProps {
 export function PerformanceDashboard({ 
   performances, 
   users, 
-  currentUser, 
   showFilters = true,
   compact = false
 }: PerformanceDashboardProps) {

--- a/lib/auth-flow-v3.ts
+++ b/lib/auth-flow-v3.ts
@@ -15,13 +15,14 @@ export interface AuthProfile {
   name: string
   email: string
   role: string
+  team_id?: string | null
   onboarding_completed?: boolean
   [key: string]: any
 }
 
 export interface AgreementStatus {
   requiresAgreement: boolean
-  status?: 'missing' | 'outdated' | 'current' | 'bypassed'
+  status?: 'missing' | 'outdated' | 'current' | 'bypassed' | 'declined' | 'pending'
   current_version?: number
   required_version?: number
 }


### PR DESCRIPTION
Migrate project to use Auth v3 and resolve all associated build-time type errors.

The migration to Auth v3 introduced several type incompatibilities, particularly where components expected a full `UserProfile` database type but received a simplified `AuthProfile`. This PR addresses these by updating component prop types, adding missing properties to `AuthProfile`, handling `null` values, and ensuring correct type assertions for roles, allowing the project to build successfully with Auth v3.

---

[Open in Web](https://cursor.com/agents?id=bc-bf45b94c-f731-4d99-b27c-bc693a737635) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bf45b94c-f731-4d99-b27c-bc693a737635)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)