### PR TITLE
The Discord login process was incorrectly redirecting you to the emai…

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthV2 } from "@/hooks/use-auth-v2";
+import { FullPageLoader } from "@/components/ui/full-page-loader";
+
+export default function AuthCallbackPage() {
+  const { isAuthenticated, isLoading, profile } = useAuthV2();
+  const router = useRouter();
+
+  useEffect(() => {
+    // This page is just a temporary loading screen.
+    // The actual redirect logic is handled by the onAuthStateChange
+    // listener in the AuthProviderV2.
+
+    // If authentication is complete, but the listener somehow hasn't redirected,
+    // we can give it a push. This is a fallback.
+    if (!isLoading && isAuthenticated && profile) {
+      // Determine redirect path based on profile
+      if (profile.role === 'pending_player' && !profile.onboarding_completed) {
+        router.push("/onboarding");
+      } else {
+        router.push("/dashboard");
+      }
+    }
+  }, [isAuthenticated, isLoading, profile, router]);
+
+  // The main purpose is to show a loading screen while the auth provider
+  // detects the new session and redirects automatically.
+  return <FullPageLoader message="Finalizing login..." />;
+}

--- a/hooks/use-auth-v2.tsx
+++ b/hooks/use-auth-v2.tsx
@@ -231,7 +231,7 @@ export function AuthProviderV2({ children }: { children: React.ReactNode }) {
         // Don't initialize if route guard is handling it
         // Route guard will initialize for protected routes
         const currentPath = window.location.pathname
-        const isPublicRoute = ['/', '/auth/confirm'].some(route => {
+        const isPublicRoute = ['/', '/auth/confirm', '/auth/callback'].some(route => {
           if (route === '/') return currentPath === '/'
           return currentPath.startsWith(route)
         })
@@ -341,7 +341,7 @@ export function AuthProviderV2({ children }: { children: React.ReactNode }) {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'discord',
         options: {
-          redirectTo: `${getSiteUrl()}/auth/confirm`
+          redirectTo: `${getSiteUrl()}/auth/callback`
         }
       })
 


### PR DESCRIPTION
…l confirmation page (`/auth/confirm`), causing a race condition and showing you an error message instead of redirecting to your dashboard.

This was because the `signInWithDiscord` function was configured to use `/auth/confirm` as its `redirectTo` target. This page contains logic specific to email verification, which fails for OAuth callbacks.

I fixed the issue by:
1. Creating a new, dedicated OAuth callback page at `/auth/callback`. This page simply displays a loading state and waits for the authentication process to complete in the background.
2. Updating the `signInWithDiscord` function in `useAuthV2` to use the new `/auth/callback` page as the `redirectTo` target.
3. Updating the public route checks to include the new callback page, preventing unnecessary auth flow re-initializations.

This change ensures that the Discord login flow is now robust and correctly redirects you to your dashboard or onboarding page after a successful login, without interfering with the email confirmation flow.