### PR TITLE
The Discord login process was incorrectly redirecting you to the emai…

### DIFF
--- a/components/route-guard-v2.tsx
+++ b/components/route-guard-v2.tsx
@@ -12,6 +12,7 @@ interface RouteGuardV2Props {
 const PUBLIC_ROUTES = [
   '/',
   '/auth/confirm',
+  '/auth/callback',
   '/debug'
 ]
 


### PR DESCRIPTION
…l confirmation page (`/auth/confirm`), or getting stuck in a redirect loop, instead of redirecting to the dashboard.

This was caused by two issues:
1. The `signInWithDiscord` function was configured to use `/auth/confirm` as its `redirectTo` target. This page contains logic specific to email verification, which fails for OAuth callbacks.
2. The `RouteGuardV2` component was too aggressive and was redirecting you away from the `/auth/callback` page before the authentication process could complete.

This commit fixes the issue by:
1. Creating a new, dedicated OAuth callback page at `/auth/callback`. This page simply displays a loading state and waits for the authentication process to complete in the background.
2. Updating the `signInWithDiscord` function in `useAuthV2` to use the new `/auth/callback` page as the `redirectTo` target.
3. Updating the `RouteGuardV2` to treat `/auth/callback` as a public route, preventing it from interfering with the authentication flow.
4. Updating the public route checks in `useAuthV2` to include the new callback page, preventing unnecessary auth flow re-initializations.

This change ensures that the Discord login flow is now robust and correctly redirects you to your dashboard or onboarding page after a successful login, without interfering with the email confirmation flow.