### PR TITLE
Filter attendance slots to current day

### DIFF
--- a/app/api/performances/route.ts
+++ b/app/api/performances/route.ts
@@ -220,13 +220,15 @@ export async function POST(request: NextRequest) {
 
 // Helper function to create match attendance
 async function createMatchAttendance(userSupabase: any, performance: any, userData: any) {
+  // Use current date for session and attendance
+  const currentDate = new Date().toISOString().split('T')[0]
+  
   // Check if session already exists for this match
-  const sessionDate = new Date().toISOString().split('T')[0] // Use current date
   const { data: existingSession, error: sessionCheckError } = await userSupabase
     .from('sessions')
     .select('id')
     .eq('team_id', performance.team_id)
-    .eq('date', sessionDate)
+    .eq('date', currentDate)
     .eq('session_type', 'tournament')
     .eq('session_subtype', 'Scrims')
     .single()
@@ -236,7 +238,6 @@ async function createMatchAttendance(userSupabase: any, performance: any, userDa
   // Create session if it doesn't exist
   if (!sessionId) {
     const sessionTitle = `Match ${performance.match_number} - ${performance.map}`
-    const sessionDate = new Date().toISOString().split('T')[0] // Use current date since we don't have match_date
     
     const { data: newSession, error: sessionCreateError } = await userSupabase
       .from('sessions')
@@ -244,7 +245,7 @@ async function createMatchAttendance(userSupabase: any, performance: any, userDa
         team_id: performance.team_id,
         session_type: 'tournament',
         session_subtype: 'Scrims',
-        date: sessionDate,
+        date: currentDate,
         start_time: '18:00:00', // Default match time
         end_time: '22:00:00',
         cutoff_time: null, // No cutoff for match sessions
@@ -277,7 +278,7 @@ async function createMatchAttendance(userSupabase: any, performance: any, userDa
       .insert({
         player_id: performance.player_id,
         team_id: performance.team_id,
-        date: sessionDate,
+        date: currentDate,
         session_time: 'Scrims', // Keep for compatibility
         session_id: sessionId,
         status: 'present',

--- a/app/api/slots/route.ts
+++ b/app/api/slots/route.ts
@@ -1,0 +1,304 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { format, isToday, startOfMonth, endOfMonth } from 'date-fns'
+
+// GET - Fetch slots with filtering
+export async function GET(request: Request) {
+  try {
+    const token = request.headers.get('authorization')?.replace('Bearer ', '')
+    
+    if (!token) {
+      return NextResponse.json({ error: 'Authorization token required' }, { status: 401 })
+    }
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token)
+    
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Get user profile
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single()
+
+    if (!profile) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+
+    const url = new URL(request.url)
+    const view = url.searchParams.get('view') // 'current', 'archived', 'all'
+    const month = url.searchParams.get('month') // YYYY-MM format
+    const teamId = url.searchParams.get('team_id')
+
+    let query = supabase
+      .from('slots')
+      .select('*, team:team_id(name, tier)')
+      .order('date', { ascending: false })
+
+    // Role-based filtering
+    const userRole = profile.role?.toLowerCase()
+    const shouldSeeAllData = ['admin', 'manager'].includes(userRole)
+
+    if (!shouldSeeAllData) {
+      if (userRole === 'coach' || userRole === 'player') {
+        query = query.eq('team_id', profile.team_id!)
+      }
+    }
+
+    // Team filtering (for admin/manager)
+    if (teamId && shouldSeeAllData) {
+      query = query.eq('team_id', teamId)
+    }
+
+    // Date filtering
+    const today = format(new Date(), 'yyyy-MM-dd')
+    
+    if (userRole === 'player') {
+      // Players only see today's slots
+      query = query.eq('date', today)
+    } else {
+      switch (view) {
+        case 'current':
+          query = query.eq('date', today)
+          break
+        case 'archived':
+          if (month) {
+            const monthDate = new Date(month + '-01')
+            const startDate = format(startOfMonth(monthDate), 'yyyy-MM-dd')
+            const endDate = format(endOfMonth(monthDate), 'yyyy-MM-dd')
+            query = query.gte('date', startDate).lte('date', endDate)
+          } else {
+            query = query.lt('date', today)
+          }
+          break
+        case 'all':
+          // No date filtering
+          break
+        default:
+          // Default to current for non-players
+          query = query.eq('date', today)
+      }
+    }
+
+    const { data: slots, error } = await query
+
+    if (error) {
+      console.error('Error fetching slots:', error)
+      return NextResponse.json({ error: 'Failed to fetch slots' }, { status: 500 })
+    }
+
+    return NextResponse.json({ 
+      slots: slots || [],
+      view: userRole === 'player' ? 'current' : (view || 'current'),
+      userRole 
+    })
+
+  } catch (error) {
+    console.error('Error in slots API:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// POST - Create new slot (managers/coaches/admins only)
+export async function POST(request: Request) {
+  try {
+    const token = request.headers.get('authorization')?.replace('Bearer ', '')
+    
+    if (!token) {
+      return NextResponse.json({ error: 'Authorization token required' }, { status: 401 })
+    }
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token)
+    
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Get user profile
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single()
+
+    if (!profile) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+
+    // Check permissions
+    const userRole = profile.role?.toLowerCase()
+    if (!['admin', 'manager', 'coach'].includes(userRole)) {
+      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+    }
+
+    const body = await request.json()
+    const { 
+      team_id, 
+      organizer, 
+      time_range, 
+      date, 
+      slot_rate = 0, 
+      number_of_slots = 1,
+      match_count = 0,
+      notes = ''
+    } = body
+
+    // Validate required fields
+    if (!team_id || !organizer || !time_range || !date) {
+      return NextResponse.json({ 
+        error: 'Missing required fields: team_id, organizer, time_range, date' 
+      }, { status: 400 })
+    }
+
+    // For coaches, ensure they can only create slots for their team
+    if (userRole === 'coach' && team_id !== profile.team_id) {
+      return NextResponse.json({ 
+        error: 'Coaches can only create slots for their own team' 
+      }, { status: 403 })
+    }
+
+    // Create slot
+    const { data: slot, error: slotError } = await supabase
+      .from('slots')
+      .insert({
+        team_id,
+        organizer,
+        time_range,
+        date: format(new Date(date), 'yyyy-MM-dd'),
+        slot_rate: Number(slot_rate),
+        number_of_slots: Number(number_of_slots),
+        match_count: Number(match_count),
+        notes
+      })
+      .select('*, team:team_id(name, tier)')
+      .single()
+
+    if (slotError) {
+      console.error('Error creating slot:', slotError)
+      return NextResponse.json({ error: 'Failed to create slot' }, { status: 500 })
+    }
+
+    // Create corresponding slot expense entry
+    if (slot && slot.slot_rate > 0) {
+      const { error: expenseError } = await supabase
+        .from('slot_expenses')
+        .insert({
+          slot_id: slot.id,
+          team_id: slot.team_id,
+          rate: slot.slot_rate,
+          total: slot.slot_rate * slot.number_of_slots
+        })
+
+      if (expenseError) {
+        console.warn('Failed to create slot expense entry:', expenseError)
+      }
+    }
+
+    // Send Discord notification if enabled
+    try {
+      const { notifySlotCreated } = await import('@/modules/discord-portal')
+      await notifySlotCreated({
+        slot_id: slot.id,
+        team_id: slot.team_id,
+        team_name: slot.team?.name || 'Unknown Team',
+        organizer: slot.organizer,
+        date: format(new Date(slot.date), 'PPP'),
+        time_range: slot.time_range,
+        match_count: slot.match_count || 0,
+        slot_rate: slot.slot_rate || 0,
+        created_by_name: profile.name || profile.email || 'Unknown',
+        created_by_id: profile.id
+      })
+    } catch (discordError) {
+      console.warn('Discord notification failed:', discordError)
+    }
+
+    return NextResponse.json({ 
+      message: 'Slot created successfully',
+      slot 
+    })
+
+  } catch (error) {
+    console.error('Error in slot creation:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// DELETE - Delete slot (managers/coaches/admins only)
+export async function DELETE(request: Request) {
+  try {
+    const token = request.headers.get('authorization')?.replace('Bearer ', '')
+    
+    if (!token) {
+      return NextResponse.json({ error: 'Authorization token required' }, { status: 401 })
+    }
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token)
+    
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Get user profile
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single()
+
+    if (!profile) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+
+    // Check permissions
+    const userRole = profile.role?.toLowerCase()
+    if (!['admin', 'manager', 'coach'].includes(userRole)) {
+      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+    }
+
+    const url = new URL(request.url)
+    const slotId = url.searchParams.get('id')
+
+    if (!slotId) {
+      return NextResponse.json({ error: 'Slot ID is required' }, { status: 400 })
+    }
+
+    // Get slot details for permission check
+    const { data: slot } = await supabase
+      .from('slots')
+      .select('team_id')
+      .eq('id', slotId)
+      .single()
+
+    if (!slot) {
+      return NextResponse.json({ error: 'Slot not found' }, { status: 404 })
+    }
+
+    // For coaches, ensure they can only delete slots for their team
+    if (userRole === 'coach' && slot.team_id !== profile.team_id) {
+      return NextResponse.json({ 
+        error: 'Coaches can only delete slots for their own team' 
+      }, { status: 403 })
+    }
+
+    // Delete slot (cascade will handle slot_expenses)
+    const { error: deleteError } = await supabase
+      .from('slots')
+      .delete()
+      .eq('id', slotId)
+
+    if (deleteError) {
+      console.error('Error deleting slot:', deleteError)
+      return NextResponse.json({ error: 'Failed to delete slot' }, { status: 500 })
+    }
+
+    return NextResponse.json({ message: 'Slot deleted successfully' })
+
+  } catch (error) {
+    console.error('Error in slot deletion:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/dashboard/attendance/page.tsx
+++ b/app/dashboard/attendance/page.tsx
@@ -349,8 +349,8 @@ export default function AttendancePage() {
           onValueChange={setActiveTab}
           defaultValue={profile?.role === 'player' ? "training" : "daily"}
           variant="default"
-          size="md"
-          responsiveMode="auto"
+          size="sm"
+          responsiveMode="dropdown"
           className="space-y-6"
         >
 

--- a/app/dashboard/attendance/page.tsx
+++ b/app/dashboard/attendance/page.tsx
@@ -31,6 +31,7 @@ import type { Database } from "@/lib/supabase"
 import { DashboardPermissions, type UserRole } from "@/lib/dashboard-permissions"
 import { DailyPracticeAttendance } from "@/components/attendance/daily-practice-attendance"
 import { PracticeSessionConfig } from "@/components/attendance/practice-session-config"
+import { DailySessionManager } from "@/components/attendance/daily-session-manager"
 
 type Attendance = Database["public"]["Tables"]["attendances"]["Row"] & {
   users?: {
@@ -333,6 +334,11 @@ export default function AttendancePage() {
               label: "Statistics",
               icon: Users
             },
+            ...((['admin', 'manager', 'coach'].includes(userRole)) ? [{
+              value: "manage-sessions",
+              label: "Manage Sessions",
+              icon: Plus
+            }] : []),
             ...((['admin', 'manager'].includes(userRole)) ? [{
               value: "config",
               label: "Session Config",
@@ -445,6 +451,12 @@ export default function AttendancePage() {
               )}
             </div>
           </TabsContent>
+
+          {(['admin', 'manager', 'coach'].includes(userRole)) && (
+            <TabsContent value="manage-sessions">
+              <DailySessionManager />
+            </TabsContent>
+          )}
 
           {['admin', 'manager'].includes(userRole) && (
             <TabsContent value="config">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -138,12 +138,7 @@ export default function OptimizedDashboardPage() {
     const actions: QuickAction[] = []
     
     if (userRole === 'player') {
-      actions.push(
-        { title: 'Submit Performance', description: 'Log your match results', href: '/dashboard/performance', icon: Target, color: 'bg-blue-500' },
-        { title: 'My Team Performance', description: 'View team performance data', href: '/dashboard/performance', icon: BarChart3, color: 'bg-green-500' },
-        { title: 'Team Roster', description: 'View team information', href: '/dashboard/team-management/roster', icon: Users, color: 'bg-purple-500' },
-        { title: 'Attendance', description: 'Mark attendance', href: '/dashboard/attendance', icon: Calendar, color: 'bg-orange-500' }
-      )
+      // No quick actions for players
     } else if (userRole === 'coach') {
       actions.push(
         { title: 'Team Performance', description: 'Analyze team metrics', href: '/dashboard/analytics', icon: BarChart3, color: 'bg-green-500' },

--- a/app/dashboard/team-management/slots/page.tsx
+++ b/app/dashboard/team-management/slots/page.tsx
@@ -13,7 +13,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Textarea } from "@/components/ui/textarea"
 import { useToast } from "@/hooks/use-toast"
 import { CalendarIcon, Trash2, Settings } from "lucide-react"
-import { format } from "date-fns"
+import { format, startOfMonth, endOfMonth } from "date-fns"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
 import { cn } from "@/lib/utils"
@@ -49,6 +49,8 @@ export default function SlotsPage() {
   const [tierDefaults, setTierDefaults] = useState<TierDefault[]>([])
   const [loading, setLoading] = useState(true)
   const [formLoading, setFormLoading] = useState(false)
+  const [currentView, setCurrentView] = useState<'current' | 'archived' | 'all'>('current')
+  const [filterMonth, setFilterMonth] = useState<Date | undefined>(new Date())
   const [newSlotData, setNewSlotData] = useState({
     team_id: "",
     organizer: "",
@@ -62,9 +64,14 @@ export default function SlotsPage() {
 
   useEffect(() => {
     fetchTeams()
-    fetchSlots()
     fetchTierDefaults()
   }, [profile])
+
+  useEffect(() => {
+    if (profile) {
+      fetchSlots(currentView, filterMonth ? format(filterMonth, 'yyyy-MM') : undefined)
+    }
+  }, [profile, currentView, filterMonth])
 
   const fetchTeams = async () => {
     try {
@@ -105,30 +112,39 @@ export default function SlotsPage() {
   const fetchSlots = async (view: 'current' | 'archived' | 'all' = 'current', month?: string) => {
     setLoading(true)
     try {
-      const params = new URLSearchParams()
-      params.append('view', view)
-      if (month) params.append('month', month)
+      const userRole = profile?.role as UserRole
+      const shouldSeeAllData = DashboardPermissions.shouldSeeAllData(userRole)
       
-      const { data: { session } } = await supabase.auth.getSession()
-      const token = session?.access_token
-      
-      if (!token) {
-        throw new Error('No authentication token available')
-      }
-      
-      const response = await fetch(`/api/slots?${params.toString()}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
+      let query = supabase.from("slots").select("*, team:team_id(name, tier)").order("date", { ascending: false })
+
+      // Filter slots based on role permissions  
+      if (!shouldSeeAllData) {
+        if (userRole === "coach" || userRole === "player") {
+          query = query.eq("team_id", profile.team_id!)
         }
-      })
-      const data = await response.json()
-      
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to fetch slots')
       }
+      // Admin and manager see all slots (no filtering)
+
+      // Date filtering based on view
+      const today = format(new Date(), 'yyyy-MM-dd')
       
-      setSlots(data.slots || [])
+      if (view === 'current') {
+        query = query.eq('date', today)
+      } else if (view === 'archived') {
+        if (month) {
+          const monthDate = new Date(month + '-01')
+          const startDate = format(startOfMonth(monthDate), 'yyyy-MM-dd')
+          const endDate = format(endOfMonth(monthDate), 'yyyy-MM-dd')
+          query = query.gte('date', startDate).lte('date', endDate)
+        } else {
+          query = query.lt('date', today)
+        }
+      }
+      // 'all' view has no date filtering
+
+      const { data, error } = await query
+      if (error) throw error
+      setSlots(data || [])
     } catch (error: any) {
       console.error("Error fetching slots:", error)
       toast({
@@ -250,7 +266,7 @@ export default function SlotsPage() {
         notes: "",
         date: new Date(),
       })
-      fetchSlots()
+      fetchSlots(currentView, filterMonth ? format(filterMonth, 'yyyy-MM') : undefined)
     } catch (error: any) {
       console.error("Error booking slot:", error)
       toast({
@@ -272,7 +288,7 @@ export default function SlotsPage() {
       const { error } = await supabase.from("slots").delete().eq("id", slotId)
       if (error) throw error
       toast({ title: "Success", description: "Slot deleted successfully." })
-      fetchSlots()
+      fetchSlots(currentView, filterMonth ? format(filterMonth, 'yyyy-MM') : undefined)
     } catch (error: any) {
       console.error("Error deleting slot:", error)
       toast({
@@ -327,10 +343,10 @@ export default function SlotsPage() {
 
   return (
     <Tabs defaultValue="booking" className="space-y-6">
-      <TabsList>
-        <TabsTrigger value="booking">Slot Booking</TabsTrigger>
-        <TabsTrigger value="list">Booked Slots</TabsTrigger>
-        {canManageSettings && <TabsTrigger value="settings">Tier Settings</TabsTrigger>}
+      <TabsList className="flex w-full flex-wrap justify-start gap-1 h-auto p-1">
+        <TabsTrigger value="booking" className="flex-1 min-w-0 text-xs sm:text-sm">Slot Booking</TabsTrigger>
+        <TabsTrigger value="list" className="flex-1 min-w-0 text-xs sm:text-sm">Booked Slots</TabsTrigger>
+        {canManageSettings && <TabsTrigger value="settings" className="flex-1 min-w-0 text-xs sm:text-sm">Tier Settings</TabsTrigger>}
       </TabsList>
 
       <TabsContent value="booking">
@@ -485,6 +501,64 @@ export default function SlotsPage() {
           <CardHeader>
             <CardTitle>Booked Slots</CardTitle>
             <CardDescription>Overview of all scheduled slots with slot-based billing.</CardDescription>
+            
+            {/* View Controls */}
+            <div className="flex flex-wrap items-center gap-4 pt-4">
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-medium">View:</label>
+                <div className="flex gap-1">
+                  <Button
+                    variant={currentView === 'current' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCurrentView('current')}
+                  >
+                    Current
+                  </Button>
+                  <Button
+                    variant={currentView === 'archived' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCurrentView('archived')}
+                  >
+                    Archive
+                  </Button>
+                  <Button
+                    variant={currentView === 'all' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCurrentView('all')}
+                  >
+                    All
+                  </Button>
+                </div>
+              </div>
+              
+              {currentView === 'archived' && (
+                <div className="flex items-center gap-2">
+                  <label className="text-sm font-medium">Month:</label>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" size="sm">
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        {filterMonth ? format(filterMonth, "MMM yyyy") : "Select month"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0">
+                      <Calendar
+                        mode="single"
+                        selected={filterMonth}
+                        onSelect={setFilterMonth}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              )}
+              
+              <div className="text-sm text-muted-foreground">
+                {currentView === 'current' && "Showing today's slots"}
+                {currentView === 'archived' && `Showing archived slots${filterMonth ? ` for ${format(filterMonth, "MMM yyyy")}` : ''}`}
+                {currentView === 'all' && "Showing all slots"}
+              </div>
+            </div>
           </CardHeader>
           <CardContent>
             <Table>

--- a/app/dashboard/team-management/slots/page.tsx
+++ b/app/dashboard/team-management/slots/page.tsx
@@ -55,6 +55,8 @@ export default function SlotsPage() {
     team_id: "",
     organizer: "",
     time_range: "",
+    start_time: "",
+    end_time: "",
     number_of_slots: 1,
     slot_rate: 0,
     match_count: 0,
@@ -260,6 +262,8 @@ export default function SlotsPage() {
         team_id: teams[0]?.id || "",
         organizer: "",
         time_range: "",
+        start_time: "",
+        end_time: "",
         number_of_slots: 1,
         slot_rate: tierDefaults.find((td) => td.tier === teams[0]?.tier)?.default_slot_rate || 0,
         match_count: 0,
@@ -414,23 +418,47 @@ export default function SlotsPage() {
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="timeRange">Time Range</Label>
-                  <Select
-                    value={newSlotData.time_range}
-                    onValueChange={(value) => setNewSlotData({ ...newSlotData, time_range: value })}
-                    required
-                  >
-                    <SelectTrigger id="timeRange">
-                      <SelectValue placeholder="Select Time Range" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {TIME_RANGES.map((range) => (
-                        <SelectItem key={range} value={range}>
-                          {range}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Label htmlFor="timeRange">Custom Time Range</Label>
+                  <div className="flex gap-2 items-center">
+                    <div className="flex-1">
+                      <Label className="text-xs text-muted-foreground">Start Time</Label>
+                      <Input
+                        type="time"
+                        value={newSlotData.start_time || ""}
+                        onChange={(e) => {
+                          const startTime = e.target.value
+                          setNewSlotData(prev => ({ 
+                            ...prev, 
+                            start_time: startTime,
+                            time_range: startTime && prev.end_time ? `${startTime} - ${prev.end_time}` : ""
+                          }))
+                        }}
+                        required
+                      />
+                    </div>
+                    <span className="text-muted-foreground pt-5">to</span>
+                    <div className="flex-1">
+                      <Label className="text-xs text-muted-foreground">End Time</Label>
+                      <Input
+                        type="time"
+                        value={newSlotData.end_time || ""}
+                        onChange={(e) => {
+                          const endTime = e.target.value
+                          setNewSlotData(prev => ({ 
+                            ...prev, 
+                            end_time: endTime,
+                            time_range: prev.start_time && endTime ? `${prev.start_time} - ${endTime}` : ""
+                          }))
+                        }}
+                        required
+                      />
+                    </div>
+                  </div>
+                  {newSlotData.time_range && (
+                    <div className="text-sm text-muted-foreground">
+                      Time Range: {newSlotData.time_range}
+                    </div>
+                  )}
                 </div>
 
                 <div className="space-y-2">

--- a/app/dashboard/team-management/slots/page.tsx
+++ b/app/dashboard/team-management/slots/page.tsx
@@ -102,25 +102,33 @@ export default function SlotsPage() {
     }
   }
 
-  const fetchSlots = async () => {
+  const fetchSlots = async (view: 'current' | 'archived' | 'all' = 'current', month?: string) => {
     setLoading(true)
     try {
-      const userRole = profile?.role as UserRole
-      const shouldSeeAllData = DashboardPermissions.shouldSeeAllData(userRole)
+      const params = new URLSearchParams()
+      params.append('view', view)
+      if (month) params.append('month', month)
       
-      let query = supabase.from("slots").select("*, team:team_id(name, tier)").order("date", { ascending: false })
-
-      // Filter slots based on role permissions  
-      if (!shouldSeeAllData) {
-        if (userRole === "coach" || userRole === "player") {
-          query = query.eq("team_id", profile.team_id!)
-        }
+      const { data: { session } } = await supabase.auth.getSession()
+      const token = session?.access_token
+      
+      if (!token) {
+        throw new Error('No authentication token available')
       }
-      // Admin and manager see all slots (no filtering)
-
-      const { data, error } = await query
-      if (error) throw error
-      setSlots(data || [])
+      
+      const response = await fetch(`/api/slots?${params.toString()}`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        }
+      })
+      const data = await response.json()
+      
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to fetch slots')
+      }
+      
+      setSlots(data.slots || [])
     } catch (error: any) {
       console.error("Error fetching slots:", error)
       toast({

--- a/app/dashboard/tryouts/[id]/page.tsx
+++ b/app/dashboard/tryouts/[id]/page.tsx
@@ -220,10 +220,10 @@ export default function TryoutDetailsPage() {
 
       {/* Tabs */}
       <Tabs defaultValue="overview" className="space-y-6">
-        <TabsList>
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="applications">Applications ({applications.length})</TabsTrigger>
-          <TabsTrigger value="evaluations">Evaluations</TabsTrigger>
+        <TabsList className="flex w-full flex-wrap justify-start gap-1 h-auto p-1">
+          <TabsTrigger value="overview" className="flex-1 min-w-0 text-xs sm:text-sm">Overview</TabsTrigger>
+          <TabsTrigger value="applications" className="flex-1 min-w-0 text-xs sm:text-sm">Applications ({applications.length})</TabsTrigger>
+          <TabsTrigger value="evaluations" className="flex-1 min-w-0 text-xs sm:text-sm">Evaluations</TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview" className="space-y-6">

--- a/components/attendance/daily-session-manager.tsx
+++ b/components/attendance/daily-session-manager.tsx
@@ -1,0 +1,636 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useAuthV2 as useAuth } from "@/hooks/use-auth-v2"
+import { supabase } from "@/lib/supabase"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/hooks/use-toast"
+import { Calendar } from "@/components/ui/calendar"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { CalendarIcon, Plus, Clock, Users, Settings } from "lucide-react"
+import { format, isToday, isFuture } from "date-fns"
+import { cn } from "@/lib/utils"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Badge } from "@/components/ui/badge"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+interface Team {
+  id: string
+  name: string
+  tier: string
+}
+
+interface Session {
+  id: string
+  name: string
+  description: string
+  date: string
+  start_time: string
+  end_time: string
+  team_id: string
+  team?: Team
+  created_at: string
+  session_type: string
+  max_participants?: number
+  is_mandatory: boolean
+}
+
+const SESSION_TYPES = [
+  { value: "practice", label: "Practice Session" },
+  { value: "scrimmage", label: "Scrimmage" },
+  { value: "strategy", label: "Strategy Review" },
+  { value: "training", label: "Training" },
+  { value: "meeting", label: "Team Meeting" }
+]
+
+const TIME_SLOTS = [
+  "09:00", "10:00", "11:00", "12:00", "13:00", "14:00", 
+  "15:00", "16:00", "17:00", "18:00", "19:00", "20:00", "21:00", "22:00"
+]
+
+export function DailySessionManager() {
+  const { profile } = useAuth()
+  const { toast } = useToast()
+  const [teams, setTeams] = useState<Team[]>([])
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [loading, setLoading] = useState(true)
+  const [formLoading, setFormLoading] = useState(false)
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date())
+  
+  const [newSessionData, setNewSessionData] = useState({
+    name: "",
+    description: "",
+    date: new Date(),
+    start_time: "",
+    end_time: "",
+    team_id: "",
+    session_type: "practice",
+    max_participants: 0,
+    is_mandatory: false
+  })
+
+  const userRole = profile?.role?.toLowerCase()
+  const canManage = ['admin', 'manager', 'coach'].includes(userRole || '')
+
+  useEffect(() => {
+    if (canManage) {
+      fetchTeams()
+      fetchSessions()
+    }
+  }, [profile, selectedDate])
+
+  const fetchTeams = async () => {
+    try {
+      let query = supabase.from("teams").select("*").order("name")
+      
+      // Coaches can only manage their own team
+      if (userRole === 'coach' && profile?.team_id) {
+        query = query.eq("id", profile.team_id)
+      }
+
+      const { data, error } = await query
+      if (error) throw error
+      
+      setTeams(data || [])
+      if (data && data.length > 0 && !newSessionData.team_id) {
+        setNewSessionData(prev => ({ ...prev, team_id: data[0].id }))
+      }
+    } catch (error) {
+      console.error("Error fetching teams:", error)
+      toast({
+        title: "Error",
+        description: "Failed to load teams",
+        variant: "destructive"
+      })
+    }
+  }
+
+  const fetchSessions = async () => {
+    try {
+      const dateStr = format(selectedDate, 'yyyy-MM-dd')
+      let query = supabase
+        .from("sessions")
+        .select("*, team:team_id(id, name, tier)")
+        .eq("date", dateStr)
+        .order("start_time")
+      
+      // Coaches only see their team's sessions
+      if (userRole === 'coach' && profile?.team_id) {
+        query = query.eq("team_id", profile.team_id)
+      }
+
+      const { data, error } = await query
+      if (error) throw error
+      
+      setSessions(data || [])
+    } catch (error) {
+      console.error("Error fetching sessions:", error)
+      toast({
+        title: "Error",
+        description: "Failed to load sessions",
+        variant: "destructive"
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCreateSession = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setFormLoading(true)
+
+    try {
+      // Validate times
+      if (newSessionData.start_time >= newSessionData.end_time) {
+        toast({
+          title: "Error",
+          description: "End time must be after start time",
+          variant: "destructive"
+        })
+        return
+      }
+
+      // Check for conflicts
+      const conflictingSessions = sessions.filter(session => {
+        const sessionStart = session.start_time
+        const sessionEnd = session.end_time
+        const newStart = newSessionData.start_time
+        const newEnd = newSessionData.end_time
+        
+        return session.team_id === newSessionData.team_id &&
+               ((newStart >= sessionStart && newStart < sessionEnd) ||
+                (newEnd > sessionStart && newEnd <= sessionEnd) ||
+                (newStart <= sessionStart && newEnd >= sessionEnd))
+      })
+
+      if (conflictingSessions.length > 0) {
+        toast({
+          title: "Error",
+          description: "Time slot conflicts with existing session",
+          variant: "destructive"
+        })
+        return
+      }
+
+      const { data, error } = await supabase
+        .from("sessions")
+        .insert({
+          name: newSessionData.name,
+          description: newSessionData.description,
+          date: format(newSessionData.date, 'yyyy-MM-dd'),
+          start_time: newSessionData.start_time,
+          end_time: newSessionData.end_time,
+          team_id: newSessionData.team_id,
+          session_type: newSessionData.session_type,
+          max_participants: newSessionData.max_participants || null,
+          is_mandatory: newSessionData.is_mandatory
+        })
+        .select()
+
+      if (error) throw error
+
+      toast({
+        title: "Success",
+        description: "Session created successfully"
+      })
+
+      // Reset form
+      setNewSessionData({
+        name: "",
+        description: "",
+        date: new Date(),
+        start_time: "",
+        end_time: "",
+        team_id: teams[0]?.id || "",
+        session_type: "practice",
+        max_participants: 0,
+        is_mandatory: false
+      })
+
+      fetchSessions()
+    } catch (error: any) {
+      console.error("Error creating session:", error)
+      toast({
+        title: "Error",
+        description: error.message || "Failed to create session",
+        variant: "destructive"
+      })
+    } finally {
+      setFormLoading(false)
+    }
+  }
+
+  const handleDeleteSession = async (sessionId: string) => {
+    if (!confirm("Are you sure you want to delete this session?")) return
+
+    try {
+      const { error } = await supabase
+        .from("sessions")
+        .delete()
+        .eq("id", sessionId)
+
+      if (error) throw error
+
+      toast({
+        title: "Success",
+        description: "Session deleted successfully"
+      })
+
+      fetchSessions()
+    } catch (error: any) {
+      console.error("Error deleting session:", error)
+      toast({
+        title: "Error",
+        description: error.message || "Failed to delete session",
+        variant: "destructive"
+      })
+    }
+  }
+
+  const generateDailySessions = async () => {
+    try {
+      setFormLoading(true)
+      const targetDate = format(selectedDate, 'yyyy-MM-dd')
+      
+      const { error } = await supabase.rpc('generate_daily_practice_sessions', {
+        target_date: targetDate
+      })
+
+      if (error) throw error
+
+      toast({
+        title: "Success",
+        description: "Daily practice sessions generated successfully"
+      })
+
+      fetchSessions()
+    } catch (error: any) {
+      console.error("Error generating daily sessions:", error)
+      toast({
+        title: "Error",
+        description: error.message || "Failed to generate daily sessions",
+        variant: "destructive"
+      })
+    } finally {
+      setFormLoading(false)
+    }
+  }
+
+  if (!canManage) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-center">
+          <h3 className="text-lg font-semibold text-red-500 mb-2">Access Denied</h3>
+          <p className="text-muted-foreground">You don't have permission to manage daily sessions.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Tabs defaultValue="create" className="space-y-4">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="create">Create Session</TabsTrigger>
+          <TabsTrigger value="manage">Manage Sessions</TabsTrigger>
+          <TabsTrigger value="generate">Auto Generate</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="create">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Plus className="h-5 w-5" />
+                Create Daily Session
+              </CardTitle>
+              <CardDescription>
+                Create custom practice sessions, scrimmages, or team meetings
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleCreateSession} className="space-y-4">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="session-name">Session Name</Label>
+                    <Input
+                      id="session-name"
+                      value={newSessionData.name}
+                      onChange={(e) => setNewSessionData(prev => ({ ...prev, name: e.target.value }))}
+                      placeholder="e.g., Morning Practice"
+                      required
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="session-type">Session Type</Label>
+                    <Select
+                      value={newSessionData.session_type}
+                      onValueChange={(value) => setNewSessionData(prev => ({ ...prev, session_type: value }))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SESSION_TYPES.map(type => (
+                          <SelectItem key={type.value} value={type.value}>
+                            {type.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="team">Team</Label>
+                    <Select
+                      value={newSessionData.team_id}
+                      onValueChange={(value) => setNewSessionData(prev => ({ ...prev, team_id: value }))}
+                      required
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select team" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {teams.map(team => (
+                          <SelectItem key={team.id} value={team.id}>
+                            {team.name} ({team.tier})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="date">Date</Label>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          className={cn(
+                            "w-full justify-start text-left font-normal",
+                            !newSessionData.date && "text-muted-foreground"
+                          )}
+                        >
+                          <CalendarIcon className="mr-2 h-4 w-4" />
+                          {newSessionData.date ? format(newSessionData.date, "PPP") : "Select date"}
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0">
+                        <Calendar
+                          mode="single"
+                          selected={newSessionData.date}
+                          onSelect={(date) => date && setNewSessionData(prev => ({ ...prev, date }))}
+                          initialFocus
+                          disabled={(date) => date < new Date()}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="start-time">Start Time</Label>
+                    <Select
+                      value={newSessionData.start_time}
+                      onValueChange={(value) => setNewSessionData(prev => ({ ...prev, start_time: value }))}
+                      required
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select start time" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {TIME_SLOTS.map(time => (
+                          <SelectItem key={time} value={time}>
+                            {time}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="end-time">End Time</Label>
+                    <Select
+                      value={newSessionData.end_time}
+                      onValueChange={(value) => setNewSessionData(prev => ({ ...prev, end_time: value }))}
+                      required
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select end time" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {TIME_SLOTS.map(time => (
+                          <SelectItem key={time} value={time}>
+                            {time}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="max-participants">Max Participants (Optional)</Label>
+                    <Input
+                      id="max-participants"
+                      type="number"
+                      min="0"
+                      value={newSessionData.max_participants}
+                      onChange={(e) => setNewSessionData(prev => ({ ...prev, max_participants: Number(e.target.value) }))}
+                      placeholder="Leave empty for unlimited"
+                    />
+                  </div>
+
+                  <div className="flex items-center space-x-2">
+                    <input
+                      type="checkbox"
+                      id="mandatory"
+                      checked={newSessionData.is_mandatory}
+                      onChange={(e) => setNewSessionData(prev => ({ ...prev, is_mandatory: e.target.checked }))}
+                      className="rounded"
+                    />
+                    <Label htmlFor="mandatory">Mandatory Attendance</Label>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    value={newSessionData.description}
+                    onChange={(e) => setNewSessionData(prev => ({ ...prev, description: e.target.value }))}
+                    placeholder="Session description, objectives, or notes..."
+                    rows={3}
+                  />
+                </div>
+
+                <Button type="submit" disabled={formLoading} className="w-full">
+                  {formLoading ? "Creating..." : "Create Session"}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="manage">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Settings className="h-5 w-5" />
+                Manage Sessions
+              </CardTitle>
+              <CardDescription>
+                View and manage sessions for selected date
+              </CardDescription>
+              <div className="flex items-center gap-4">
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline">
+                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      {format(selectedDate, "PPP")}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0">
+                    <Calendar
+                      mode="single"
+                      selected={selectedDate}
+                      onSelect={(date) => date && setSelectedDate(date)}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+                <Badge variant={isToday(selectedDate) ? "default" : "secondary"}>
+                  {isToday(selectedDate) ? "Today" : isFuture(selectedDate) ? "Future" : "Past"}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {loading ? (
+                <div className="text-center py-8">Loading sessions...</div>
+              ) : sessions.length > 0 ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Session</TableHead>
+                      <TableHead>Team</TableHead>
+                      <TableHead>Time</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sessions.map(session => (
+                      <TableRow key={session.id}>
+                        <TableCell>
+                          <div>
+                            <div className="font-medium">{session.name}</div>
+                            {session.description && (
+                              <div className="text-sm text-muted-foreground">{session.description}</div>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>{session.team?.name}</TableCell>
+                        <TableCell className="flex items-center gap-1">
+                          <Clock className="h-4 w-4" />
+                          {session.start_time} - {session.end_time}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">
+                            {SESSION_TYPES.find(t => t.value === session.session_type)?.label || session.session_type}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          {session.is_mandatory && (
+                            <Badge variant="destructive">Mandatory</Badge>
+                          )}
+                          {session.max_participants && (
+                            <Badge variant="secondary">
+                              <Users className="h-3 w-3 mr-1" />
+                              Max {session.max_participants}
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => handleDeleteSession(session.id)}
+                          >
+                            Delete
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <div className="text-center py-8 text-muted-foreground">
+                  No sessions scheduled for {format(selectedDate, "PPP")}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="generate">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Clock className="h-5 w-5" />
+                Auto Generate Daily Sessions
+              </CardTitle>
+              <CardDescription>
+                Automatically generate practice sessions based on team configurations
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div className="flex items-center gap-4">
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline">
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        {format(selectedDate, "PPP")}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0">
+                      <Calendar
+                        mode="single"
+                        selected={selectedDate}
+                        onSelect={(date) => date && setSelectedDate(date)}
+                        initialFocus
+                        disabled={(date) => date < new Date()}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                <div className="bg-muted p-4 rounded-lg">
+                  <h4 className="font-semibold mb-2">Auto Generation Rules:</h4>
+                  <ul className="text-sm text-muted-foreground space-y-1">
+                    <li>• Creates practice sessions based on team practice configurations</li>
+                    <li>• Avoids conflicts with existing sessions</li>
+                    <li>• Uses team-specific time preferences when available</li>
+                    <li>• Only generates sessions for future dates</li>
+                  </ul>
+                </div>
+
+                <Button
+                  onClick={generateDailySessions}
+                  disabled={formLoading || !isFuture(selectedDate) && !isToday(selectedDate)}
+                  className="w-full"
+                >
+                  {formLoading ? "Generating..." : "Generate Daily Sessions"}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/components/attendance/daily-session-manager.tsx
+++ b/components/attendance/daily-session-manager.tsx
@@ -295,10 +295,10 @@ export function DailySessionManager() {
   return (
     <div className="space-y-6">
       <Tabs defaultValue="create" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="create">Create Session</TabsTrigger>
-          <TabsTrigger value="manage">Manage Sessions</TabsTrigger>
-          <TabsTrigger value="generate">Auto Generate</TabsTrigger>
+        <TabsList className="flex w-full flex-wrap justify-start gap-1 h-auto p-1">
+          <TabsTrigger value="create" className="flex-1 min-w-0 text-xs sm:text-sm">Create Session</TabsTrigger>
+          <TabsTrigger value="manage" className="flex-1 min-w-0 text-xs sm:text-sm">Manage Sessions</TabsTrigger>
+          <TabsTrigger value="generate" className="flex-1 min-w-0 text-xs sm:text-sm">Auto Generate</TabsTrigger>
         </TabsList>
 
         <TabsContent value="create">

--- a/components/dashboard/role-based-dashboard.tsx
+++ b/components/dashboard/role-based-dashboard.tsx
@@ -306,32 +306,10 @@ const QUICK_ACTIONS: Record<UserRole, Array<{
     }
   ],
   player: [
-    {
-      label: 'My Performance',
-      href: '/dashboard/performance',
-      icon: Target,
-      description: 'View your stats'
-    },
-    {
-      label: 'My Profile',
-      href: '/dashboard/profile',
-      icon: Users,
-      description: 'Update your profile'
-    },
-    {
-      label: 'Team Schedule',
-      href: '/dashboard/attendance',
-      icon: CalendarCheck,
-      description: 'View training schedule'
-    }
+    // No quick actions for players
   ],
   pending_player: [
-    {
-      label: 'Complete Profile',
-      href: '/dashboard/profile',
-      icon: Users,
-      description: 'Finish profile setup'
-    }
+    // No quick actions for pending players
   ],
   awaiting_approval: [
     {

--- a/components/performance/smart-slot-selector.tsx
+++ b/components/performance/smart-slot-selector.tsx
@@ -12,8 +12,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { CalendarIcon, Plus, Search } from 'lucide-react'
-import { format } from 'date-fns'
+import { CalendarIcon, Plus, Search, Archive, Filter } from 'lucide-react'
+import { format, isToday, startOfMonth, endOfMonth } from 'date-fns'
 import { cn } from '@/lib/utils'
 import type { Database } from '@/lib/supabase'
 
@@ -43,12 +43,14 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
   const [loading, setLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
   const [showQuickAdd, setShowQuickAdd] = useState(false)
+  const [showArchived, setShowArchived] = useState(false)
+  const [filterMonth, setFilterMonth] = useState<Date | undefined>(new Date())
   
   // Quick add form state
   const [quickAddData, setQuickAddData] = useState({
     organizer: '',
     time_range: '',
-    date: undefined as Date | undefined,
+    date: new Date(), // Default to today
     team_id: '',
     slot_rate: 0
   })
@@ -56,13 +58,14 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
   const userRole = profile?.role as UserRole
   const shouldSeeAllData = DashboardPermissions.shouldSeeAllData(userRole)
   const isAdminOrManager = ['admin', 'manager'].includes(userRole)
+  const isPlayer = userRole === 'player'
 
   useEffect(() => {
     fetchSlots()
     if (isAdminOrManager) {
       fetchTeams()
     }
-  }, [profile])
+  }, [profile, showArchived, filterMonth])
 
   const fetchSlots = async () => {
     try {
@@ -70,10 +73,28 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
         .select("*, team:team_id(name)")
         .order("date", { ascending: false })
 
-      // Filter based on role
+      // Role-based filtering
       if (!shouldSeeAllData) {
         if (userRole === "coach" || userRole === "player") {
           query = query.eq("team_id", profile?.team_id!)
+        }
+      }
+
+      // Date filtering based on role and archive view
+      if (isPlayer) {
+        // Players only see today's slots
+        const today = format(new Date(), 'yyyy-MM-dd')
+        query = query.eq("date", today)
+      } else if (isAdminOrManager) {
+        if (showArchived && filterMonth) {
+          // Show archived slots for selected month
+          const startDate = format(startOfMonth(filterMonth), 'yyyy-MM-dd')
+          const endDate = format(endOfMonth(filterMonth), 'yyyy-MM-dd')
+          query = query.gte("date", startDate).lte("date", endDate)
+        } else if (!showArchived) {
+          // Show only today's slots for current view
+          const today = format(new Date(), 'yyyy-MM-dd')
+          query = query.eq("date", today)
         }
       }
 
@@ -112,7 +133,8 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
         time_range: quickAddData.time_range,
         date: format(quickAddData.date, 'yyyy-MM-dd'),
         team_id: quickAddData.team_id,
-        slot_rate: quickAddData.slot_rate
+        slot_rate: quickAddData.slot_rate,
+        match_count: 0 // Default value
       }).select("*, team:team_id(name)").single()
 
       if (error) throw error
@@ -126,7 +148,7 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
       setQuickAddData({
         organizer: '',
         time_range: '',
-        date: undefined,
+        date: new Date(),
         team_id: '',
         slot_rate: 0
       })
@@ -161,7 +183,7 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
               </DialogTrigger>
               <DialogContent>
                 <DialogHeader>
-                  <DialogTitle>Quick Add Slot</DialogTitle>
+                  <DialogTitle>Quick Add Daily Slot</DialogTitle>
                 </DialogHeader>
                 <div className="space-y-4">
                   <div>
@@ -201,8 +223,9 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
                         <Calendar
                           mode="single"
                           selected={quickAddData.date}
-                          onSelect={(date) => setQuickAddData(prev => ({ ...prev, date }))}
+                          onSelect={(date) => date && setQuickAddData(prev => ({ ...prev, date }))}
                           initialFocus
+                          disabled={(date) => date < new Date()}
                         />
                       </PopoverContent>
                     </Popover>
@@ -233,13 +256,20 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
                     />
                   </div>
                   <Button onClick={handleQuickAdd} className="w-full">
-                    Create Slot
+                    Create Daily Slot
                   </Button>
                 </div>
               </DialogContent>
             </Dialog>
           )}
         </div>
+
+        {/* Show status for players */}
+        {isPlayer && (
+          <div className="text-xs text-muted-foreground">
+            Showing only today's available slots
+          </div>
+        )}
         
         {loading ? (
           <Input disabled value="Loading slots..." />
@@ -259,105 +289,145 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
           </Select>
         ) : (
           <div className="text-red-500 text-sm">
-            No slots available. {isAdminOrManager ? 'Click Quick Add to create one.' : 'Please contact your coach or admin.'}
+            {isPlayer 
+              ? "No slots available for today. Please contact your coach or admin."
+              : `No slots available. ${isAdminOrManager ? 'Click Quick Add to create one.' : 'Please contact your coach or admin.'}`
+            }
           </div>
         )}
       </div>
     )
   }
 
-  // For admin/manager with many slots, use search interface
+  // For admin/manager with many slots, use advanced search interface
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <Label htmlFor="slot">Slot</Label>
-        <Dialog open={showQuickAdd} onOpenChange={setShowQuickAdd}>
-          <DialogTrigger asChild>
-            <Button variant="outline" size="sm">
-              <Plus className="h-4 w-4 mr-1" />
-              Quick Add
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Quick Add Slot</DialogTitle>
-            </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label>Organizer</Label>
-                <Input 
-                  value={quickAddData.organizer}
-                  onChange={(e) => setQuickAddData(prev => ({ ...prev, organizer: e.target.value }))}
-                  placeholder="Tournament/League name"
-                />
-              </div>
-              <div>
-                <Label>Time Range</Label>
-                <Select 
-                  value={quickAddData.time_range} 
-                  onValueChange={(value) => setQuickAddData(prev => ({ ...prev, time_range: value }))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select time range" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {TIME_RANGES.map(range => (
-                      <SelectItem key={range} value={range}>{range}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label>Date</Label>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button variant="outline" className="w-full justify-start text-left font-normal">
-                      <CalendarIcon className="mr-2 h-4 w-4" />
-                      {quickAddData.date ? format(quickAddData.date, "PPP") : "Pick a date"}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0">
-                    <Calendar
-                      mode="single"
-                      selected={quickAddData.date}
-                      onSelect={(date) => setQuickAddData(prev => ({ ...prev, date }))}
-                      initialFocus
-                    />
-                  </PopoverContent>
-                </Popover>
-              </div>
-              <div>
-                <Label>Team</Label>
-                <Select 
-                  value={quickAddData.team_id} 
-                  onValueChange={(value) => setQuickAddData(prev => ({ ...prev, team_id: value }))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select team" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {teams.map(team => (
-                      <SelectItem key={team.id} value={team.id}>{team.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label>Slot Rate</Label>
-                <Input 
-                  type="number"
-                  value={quickAddData.slot_rate}
-                  onChange={(e) => setQuickAddData(prev => ({ ...prev, slot_rate: Number(e.target.value) }))}
-                  placeholder="0"
-                />
-              </div>
-              <Button onClick={handleQuickAdd} className="w-full">
-                Create Slot
+        <div className="flex gap-2">
+          {/* Archive toggle */}
+          <Button
+            variant={showArchived ? "default" : "outline"}
+            size="sm"
+            onClick={() => setShowArchived(!showArchived)}
+          >
+            <Archive className="h-4 w-4 mr-1" />
+            {showArchived ? "Current" : "Archive"}
+          </Button>
+          
+          <Dialog open={showQuickAdd} onOpenChange={setShowQuickAdd}>
+            <DialogTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Plus className="h-4 w-4 mr-1" />
+                Quick Add
               </Button>
-            </div>
-          </DialogContent>
-        </Dialog>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Quick Add Daily Slot</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div>
+                  <Label>Organizer</Label>
+                  <Input 
+                    value={quickAddData.organizer}
+                    onChange={(e) => setQuickAddData(prev => ({ ...prev, organizer: e.target.value }))}
+                    placeholder="Tournament/League name"
+                  />
+                </div>
+                <div>
+                  <Label>Time Range</Label>
+                  <Select 
+                    value={quickAddData.time_range} 
+                    onValueChange={(value) => setQuickAddData(prev => ({ ...prev, time_range: value }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select time range" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TIME_RANGES.map(range => (
+                        <SelectItem key={range} value={range}>{range}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label>Date</Label>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" className="w-full justify-start text-left font-normal">
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        {quickAddData.date ? format(quickAddData.date, "PPP") : "Pick a date"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0">
+                      <Calendar
+                        mode="single"
+                        selected={quickAddData.date}
+                        onSelect={(date) => date && setQuickAddData(prev => ({ ...prev, date }))}
+                        initialFocus
+                        disabled={(date) => date < new Date()}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <div>
+                  <Label>Team</Label>
+                  <Select 
+                    value={quickAddData.team_id} 
+                    onValueChange={(value) => setQuickAddData(prev => ({ ...prev, team_id: value }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select team" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {teams.map(team => (
+                        <SelectItem key={team.id} value={team.id}>{team.name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label>Slot Rate</Label>
+                  <Input 
+                    type="number"
+                    value={quickAddData.slot_rate}
+                    onChange={(e) => setQuickAddData(prev => ({ ...prev, slot_rate: Number(e.target.value) }))}
+                    placeholder="0"
+                  />
+                </div>
+                <Button onClick={handleQuickAdd} className="w-full">
+                  Create Daily Slot
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
       </div>
+
+      {/* Archive month filter */}
+      {showArchived && (
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4" />
+          <Label className="text-sm">Filter by month:</Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm">
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {filterMonth ? format(filterMonth, "MMMM yyyy") : "Select month"}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0">
+              <Calendar
+                mode="single"
+                selected={filterMonth}
+                onSelect={setFilterMonth}
+                initialFocus
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+      )}
 
       <div className="relative">
         <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
@@ -367,6 +437,13 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
           placeholder="Search slots by organizer, time, team, or date..."
           className="pl-10"
         />
+      </div>
+
+      <div className="text-xs text-muted-foreground">
+        {showArchived 
+          ? `Showing archived slots for ${filterMonth ? format(filterMonth, "MMMM yyyy") : "all time"}`
+          : "Showing today's slots only"
+        }
       </div>
 
       <div className="max-h-48 overflow-y-auto border rounded-md">
@@ -386,6 +463,11 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
                   <div className="text-gray-600">
                     {slot.time_range} • {slot.date}
                     {slot.team && ` • ${slot.team.name}`}
+                    {!isToday(new Date(slot.date)) && (
+                      <span className="ml-2 text-xs bg-gray-600 text-white px-1 rounded">
+                        Past
+                      </span>
+                    )}
                   </div>
                 </div>
               </Card>
@@ -398,7 +480,7 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
           </div>
         ) : (
           <div className="p-4 text-center text-gray-500">
-            {searchTerm ? 'No slots match your search.' : 'No slots available.'}
+            {searchTerm ? 'No slots match your search.' : showArchived ? 'No archived slots found for selected period.' : 'No slots available for today.'}
           </div>
         )}
       </div>

--- a/components/performance/smart-slot-selector.tsx
+++ b/components/performance/smart-slot-selector.tsx
@@ -50,6 +50,8 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
   const [quickAddData, setQuickAddData] = useState({
     organizer: '',
     time_range: '',
+    start_time: '',
+    end_time: '',
     date: new Date(), // Default to today
     team_id: '',
     slot_rate: 0
@@ -148,6 +150,8 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
       setQuickAddData({
         organizer: '',
         time_range: '',
+        start_time: '',
+        end_time: '',
         date: new Date(),
         team_id: '',
         slot_rate: 0
@@ -195,20 +199,45 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
                     />
                   </div>
                   <div>
-                    <Label>Time Range</Label>
-                    <Select 
-                      value={quickAddData.time_range} 
-                      onValueChange={(value) => setQuickAddData(prev => ({ ...prev, time_range: value }))}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select time range" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {TIME_RANGES.map(range => (
-                          <SelectItem key={range} value={range}>{range}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <Label>Custom Time Range</Label>
+                    <div className="flex gap-2 items-center">
+                      <div className="flex-1">
+                        <Label className="text-xs text-muted-foreground">Start</Label>
+                        <Input
+                          type="time"
+                          value={quickAddData.start_time}
+                          onChange={(e) => {
+                            const startTime = e.target.value
+                            setQuickAddData(prev => ({ 
+                              ...prev, 
+                              start_time: startTime,
+                              time_range: startTime && prev.end_time ? `${startTime} - ${prev.end_time}` : ""
+                            }))
+                          }}
+                        />
+                      </div>
+                      <span className="text-muted-foreground pt-5">to</span>
+                      <div className="flex-1">
+                        <Label className="text-xs text-muted-foreground">End</Label>
+                        <Input
+                          type="time"
+                          value={quickAddData.end_time}
+                          onChange={(e) => {
+                            const endTime = e.target.value
+                            setQuickAddData(prev => ({ 
+                              ...prev, 
+                              end_time: endTime,
+                              time_range: prev.start_time && endTime ? `${prev.start_time} - ${endTime}` : ""
+                            }))
+                          }}
+                        />
+                      </div>
+                    </div>
+                    {quickAddData.time_range && (
+                      <div className="text-sm text-muted-foreground mt-1">
+                        Range: {quickAddData.time_range}
+                      </div>
+                    )}
                   </div>
                   <div>
                     <Label>Date</Label>
@@ -336,20 +365,45 @@ export function SmartSlotSelector({ value, onValueChange, required }: SmartSlotS
                   />
                 </div>
                 <div>
-                  <Label>Time Range</Label>
-                  <Select 
-                    value={quickAddData.time_range} 
-                    onValueChange={(value) => setQuickAddData(prev => ({ ...prev, time_range: value }))}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select time range" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {TIME_RANGES.map(range => (
-                        <SelectItem key={range} value={range}>{range}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Label>Custom Time Range</Label>
+                  <div className="flex gap-2 items-center">
+                    <div className="flex-1">
+                      <Label className="text-xs text-muted-foreground">Start</Label>
+                      <Input
+                        type="time"
+                        value={quickAddData.start_time}
+                        onChange={(e) => {
+                          const startTime = e.target.value
+                          setQuickAddData(prev => ({ 
+                            ...prev, 
+                            start_time: startTime,
+                            time_range: startTime && prev.end_time ? `${startTime} - ${prev.end_time}` : ""
+                          }))
+                        }}
+                      />
+                    </div>
+                    <span className="text-muted-foreground pt-5">to</span>
+                    <div className="flex-1">
+                      <Label className="text-xs text-muted-foreground">End</Label>
+                      <Input
+                        type="time"
+                        value={quickAddData.end_time}
+                        onChange={(e) => {
+                          const endTime = e.target.value
+                          setQuickAddData(prev => ({ 
+                            ...prev, 
+                            end_time: endTime,
+                            time_range: prev.start_time && endTime ? `${prev.start_time} - ${endTime}` : ""
+                          }))
+                        }}
+                      />
+                    </div>
+                  </div>
+                  {quickAddData.time_range && (
+                    <div className="text-sm text-muted-foreground mt-1">
+                      Range: {quickAddData.time_range}
+                    </div>
+                  )}
                 </div>
                 <div>
                   <Label>Date</Label>

--- a/database-schema-updates.sql
+++ b/database-schema-updates.sql
@@ -1,0 +1,180 @@
+-- Database Schema Updates for Missing Tables/Columns
+-- Run this script to add missing schema elements that are not in the current database
+
+-- Note: Based on the provided schema, most tables already exist.
+-- This script only adds missing elements that might be referenced in the new components.
+
+-- Add any missing columns to existing tables if needed
+-- (Most columns appear to already exist in the provided schema)
+
+-- Add training_details column to attendances table if it doesn't exist
+-- This is used by the training session attendance system
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'attendances' 
+        AND column_name = 'training_details'
+    ) THEN
+        ALTER TABLE public.attendances 
+        ADD COLUMN training_details jsonb DEFAULT NULL;
+    END IF;
+END $$;
+
+-- Add verification status and manager notes to attendances for training verification
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'attendances' 
+        AND column_name = 'verification_status'
+    ) THEN
+        ALTER TABLE public.attendances 
+        ADD COLUMN verification_status text DEFAULT 'pending' 
+        CHECK (verification_status = ANY (ARRAY['pending'::text, 'approved'::text, 'denied'::text]));
+    END IF;
+END $$;
+
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'attendances' 
+        AND column_name = 'manager_notes'
+    ) THEN
+        ALTER TABLE public.attendances 
+        ADD COLUMN manager_notes text DEFAULT NULL;
+    END IF;
+END $$;
+
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'attendances' 
+        AND column_name = 'verified_by'
+    ) THEN
+        ALTER TABLE public.attendances 
+        ADD COLUMN verified_by uuid DEFAULT NULL,
+        ADD CONSTRAINT attendances_verified_by_fkey 
+        FOREIGN KEY (verified_by) REFERENCES public.users(id);
+    END IF;
+END $$;
+
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'attendances' 
+        AND column_name = 'verified_at'
+    ) THEN
+        ALTER TABLE public.attendances 
+        ADD COLUMN verified_at timestamp with time zone DEFAULT NULL;
+    END IF;
+END $$;
+
+-- Add name and description columns to sessions table for daily session manager
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'sessions' 
+        AND column_name = 'name'
+    ) THEN
+        ALTER TABLE public.sessions 
+        ADD COLUMN name text DEFAULT NULL;
+    END IF;
+END $$;
+
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'sessions' 
+        AND column_name = 'max_participants'
+    ) THEN
+        ALTER TABLE public.sessions 
+        ADD COLUMN max_participants integer DEFAULT NULL 
+        CHECK (max_participants > 0 OR max_participants IS NULL);
+    END IF;
+END $$;
+
+-- Add indexes for better performance on frequently queried columns
+CREATE INDEX IF NOT EXISTS idx_attendances_verification_status 
+ON public.attendances(verification_status);
+
+CREATE INDEX IF NOT EXISTS idx_attendances_date_team 
+ON public.attendances(date, team_id);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_date_team 
+ON public.sessions(date, team_id);
+
+CREATE INDEX IF NOT EXISTS idx_slots_date_team 
+ON public.slots(date, team_id);
+
+-- Add RLS policies for new columns if needed
+-- (Existing RLS policies should cover the new columns)
+
+-- Create function to generate daily practice sessions if it doesn't exist
+CREATE OR REPLACE FUNCTION generate_daily_practice_sessions(target_date date)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    -- This function generates daily practice sessions based on practice_session_config
+    -- Insert sessions for teams that have active configurations
+    INSERT INTO public.sessions (
+        team_id,
+        session_type,
+        session_subtype,
+        date,
+        start_time,
+        end_time,
+        cutoff_time,
+        title,
+        description,
+        is_mandatory,
+        created_by
+    )
+    SELECT 
+        psc.team_id,
+        'practice'::text,
+        psc.session_subtype,
+        target_date,
+        psc.start_time,
+        psc.end_time,
+        psc.cutoff_time,
+        CONCAT(psc.session_subtype, ' Practice - ', target_date),
+        'Auto-generated daily practice session',
+        true,
+        psc.created_by
+    FROM public.practice_session_config psc
+    WHERE psc.is_active = true
+    AND NOT EXISTS (
+        -- Don't create if session already exists for this team/date/subtype
+        SELECT 1 FROM public.sessions s
+        WHERE s.team_id = psc.team_id
+        AND s.date = target_date
+        AND s.session_subtype = psc.session_subtype
+        AND s.session_type = 'practice'
+    );
+END;
+$$;
+
+-- Grant execute permission on the function
+GRANT EXECUTE ON FUNCTION generate_daily_practice_sessions(date) TO authenticated;
+
+-- Add comments for documentation
+COMMENT ON COLUMN public.attendances.training_details IS 'JSON data for training session details including mode, hours, screenshots, etc.';
+COMMENT ON COLUMN public.attendances.verification_status IS 'Status of manager verification for training attendance';
+COMMENT ON COLUMN public.attendances.manager_notes IS 'Notes added by manager during verification process';
+COMMENT ON COLUMN public.attendances.verified_by IS 'User ID of manager who verified the attendance';
+COMMENT ON COLUMN public.attendances.verified_at IS 'Timestamp when attendance was verified';
+COMMENT ON COLUMN public.sessions.name IS 'Custom name for the session';
+COMMENT ON COLUMN public.sessions.max_participants IS 'Maximum number of participants allowed in the session';
+
+-- Update any existing data if needed
+-- (No data updates required for this implementation)
+
+COMMIT;


### PR DESCRIPTION
Filter slots for players to show only same-day options and add comprehensive daily session management for admins/managers.

This resolves the issue where players were seeing past slots in the performance submission, improving clarity and usability for players while providing robust tools for managers/admins to create, manage, and archive sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-97ea45e3-0f9d-4dda-ac99-2f2c99e5322e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97ea45e3-0f9d-4dda-ac99-2f2c99e5322e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

